### PR TITLE
`threat-model.schema.json`: Numerous updates, partially based on 2025-04-02 CycloneDX WG feedback

### DIFF
--- a/threat-model.schema.json
+++ b/threat-model.schema.json
@@ -1,0 +1,974 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/OWASP/www-project-threat-model-library/blob/main/threat-model-schema.json",
+    "$comment": "When updating the schema `$id`, also update the value of the constant `$schema` property below.",
+    "title": "Threat-model-library-schema",
+
+    "$defs": {
+        "version": {
+            "title": "Structured version number",
+            "type": "string",
+            "pattern": "^\\d+(\\.\\d+)*$"
+        },
+
+        "symbolic-name": {
+            "title": "Symbolic name of an object",
+            "type": "string",
+            "pattern": "^[0-9a-z-]+$"
+        },
+        "typed-symbolic-name": {
+            "title": "Symbolic name of an object of a specified type",
+            "type": "object",
+            "required": ["type", "name"],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "title": "Type of the object being referenced",
+                    "description": "The type of the object being referenced, as a '#/$defs/...' or simple '...' type reference.",
+                    "type": "string"
+                },
+                "name": {
+                    "$ref": "#/$defs/symbolic-name"
+                }
+            }
+        },
+
+        "date-or-datetime": {
+            "title": "Date (YYYY-MM-DD) or datetime (YYYY-MM-DDThh:mm:ss)",
+            "oneOf": [
+                {
+                    "type": "string",
+                    "format": "date"
+                },
+                {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            ]
+        },
+
+        "business-criticality": {
+            "$ref": "#/$defs/degree"
+        },
+        "mitigation-status": {
+            "enum": ["assumed", "active", "suggested", "under_review", "approved", "scheduled", "retired", "wont_do"]
+        },
+        "data-sensitivity": {
+            "enum": ["pii", "phi", "fin", "ip", "cred", "biz", "gov", "pci"]
+        },
+        "degree": {
+            "enum": ["minimal", "low", "moderate", "high", "maximal"]
+        },
+        "exposure": {
+            "enum": ["internal", "external"]
+        },
+        "impact": {
+            "enum": ["negligible", "minor", "moderate", "major", "severe"]
+        },
+        "likelihood": {
+            "enum": ["rare", "unlikely", "possible", "likely", "certain"]
+        },
+        "priority": {
+            "enum": ["none", "low", "medium", "high", "critical"]
+        },
+        "risk-score": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 25
+        },
+        "tier": {
+            "enum": ["1_mission_critical", "2_business_critical", "3_important", "4_non_critical"]
+        },
+        
+
+        "access-level": {
+            "enum": ["anonymous", "user", "admin"]
+        },
+        "access_control_method": {
+            "enum": ["acl", "rbac", "mac", "dac", "abac"]
+        },
+        "authentication-method": {
+            "enum": ["password", "otp", "public_key", "token", "biometrics", "sso", "social"]
+        },
+
+        "data-store-type": {
+            "enum": ["sql", "key_value", "document", "object", "graph", "time_series"]
+        },
+
+        "trust-boundary-ref": {
+            "type": "object",
+            "required": ["trust_zone_a", "trust_zone_b"],
+            "additionalProperties": false,
+            "properties": {
+                "trust_zone_a": {
+                    "$ref": "#/$defs/symbolic-name"
+                },
+                "trust_zone_b": {
+                    "$ref": "#/$defs/symbolic-name"
+                }
+            }
+        },
+
+        "cwe-ref": {
+            "type": "object",
+            "required": ["cwe_id"],
+            "additionalProperties": false,
+            "properties": {
+                "cwe_id": {
+                    "type": "integer"
+                },
+                "cwe_title": {
+                    "type": "string"
+                }
+            }
+        },
+        "capec-ref": {
+            "type": "object",
+            "required": ["capec_id"],
+            "additionalProperties": false,
+            "properties": {
+                "capec_id": {
+                    "type": "integer"
+                },
+                "capec_title": {
+                    "type": "string"
+                }
+            }
+        },
+
+        "attacker-skill-and-knowledge": {
+            "enum": ["script_kid", "insider", "engineer", "expert_engineer", "oc_sponsored", "state_sponsored"]
+        },
+
+        "target": {
+            "type": "object",
+            "required": [
+                "title",
+                "description",
+                "business_criticality",
+                "data_sensitivity",
+                "exposure",
+                "tier"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "title": {
+                    "title": "Short description of the target of this threat model of an application or service",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Definition of the target of an application or service",
+                    "type": "string"
+                },
+                "business_criticality": {
+                    "title": "Business criticality of the application or service",
+                    "$ref": "#/$defs/business-criticality"
+                },
+                "data_sensitivity": {
+                    "title": "Types of sensitive data handled by the application or service",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/data-sensitivity"
+                    }
+                },
+                "exposure": {
+                    "$ref": "#/$defs/exposure"
+                },
+                "tier": {
+                    "title": "Tier of the application or service",
+                    "$ref": "#/$defs/tier"
+                }
+            }
+        },
+
+        "diagram": {
+            "type": "object",
+            "required": ["title", "type", "source"],
+            "additionalProperties": false,
+            "properties": {
+                "title": {
+                    "title": "Title of the diagram",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description of the diagram",
+                    "type": "string"
+                },
+                "link": {
+                    "title": "Link to the source of the diagram",
+                    "type": "string",
+                    "format": "uri"
+                },
+                "type": {
+                    "title": "MIME type of the diagram",
+                    "$comment": "ordered by prominence as a diagram format in a threat modeling context",
+                    "enum": [
+                        "graphviz",
+                        "mermaid",
+                        "plantuml",
+                        "svg"
+                    ]
+                },
+                "source": {
+                    "title": "Source code of the diagram",
+                    "type": "string"
+                }
+            }
+        },
+
+        "trust-zone": {
+            "type": "object",
+            "required": ["symbolic_name", "title", "description"],
+            "additionalProperties": false,
+            "properties": {
+                "symbolic_name": {
+                    "title": "Symbolic name of the trust zone",
+                    "$ref": "#/$defs/symbolic-name"
+                },
+                "title": {
+                    "title": "Title of the trust zone",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description of the trust zone",
+                    "type": "string"
+                }
+            }
+        },
+
+        "trust-boundary": {
+            "type": "object",
+            "required": [
+                "trust_zone_a",
+                "trust_zone_b"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "trust_zone_a": {
+                    "title": "Symbolic name of the first trust zone",
+                    "$ref": "#/$defs/symbolic-name"
+                },
+                "trust_zone_b": {
+                    "title": "Symbolic name of the second trust zone",
+                    "$ref": "#/$defs/symbolic-name"
+                },
+                "access_control_method": {
+                    "title": "Access control method used between the two trust zones",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/access_control_method"
+                    }
+                },
+                "authentication_method": {
+                    "title": "Authentication method used between the two trust zones",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/authentication-method"
+                    }
+                },
+                "access_token_expires": {
+                    "title": "Whether access tokens ever expire",
+                    "type": "boolean"
+                },
+                "access_token_ttl": {
+                    "title": "TTL (Time To Live) in seconds of access tokens",
+                    "type": "integer"
+                },
+                "has_refresh_token": {
+                    "title": "Whether refresh tokens are used",
+                    "type": "boolean"
+                },
+                "refresh_token_expires": {
+                    "title": "Whether refresh tokens ever expire",
+                    "type": "boolean"
+                },
+                "refresh_token_ttl": {
+                    "title": "TTL (Time To Live) in seconds of refresh tokens",
+                    "type": "integer"
+                },
+                "can_user_logout": {
+                    "title": "Whether users can explicitly log out of the application or service",
+                    "type": "boolean"
+                },
+                "can_system_logout": {
+                    "title": "Whether the system ever logs out the user",
+                    "type": "boolean"
+                }
+            }
+        },
+
+        "actor": {
+            "type": "object",
+            "required": [
+                "symbolic_name",
+                "title",
+                "description",
+                "type"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "symbolic_name": {
+                    "title": "Symbolic name of the actor",
+                    "$ref": "#/$defs/symbolic-name"
+                },
+                "title": {
+                    "title": "Name of the actor",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description of the actor and their role",
+                    "type": "string"
+                },
+                "type": {
+                    "title": "Type of actor",
+                    "enum": ["system", "user", "power_user", "administrator", "engineer", "third_party"]
+                },
+                "permissions": {
+                    "title": "Free-form description of permissions typically available to the actor",
+                    "type": "string"
+                }
+            }
+        },
+
+        "component": {
+            "type": "object",
+            "required": [
+                "symbolic_name",
+                "title",
+                "description",
+                "trust_zone"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "symbolic_name": {
+                    "title": "Symbolic name of the component",
+                    "$ref": "#/$defs/symbolic-name"
+                },
+                "title": {
+                    "title": "Title of the component",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description of the component and its purpose",
+                    "type": "string"
+                },
+                "parent_component": {
+                    "title": "Symbolic name of the parent component",
+                    "$ref": "#/$defs/symbolic-name"
+                },
+                "trust_zone": {
+                    "title": "Symbolic name of the trust zone where the component is located",
+                    "$ref": "#/$defs/symbolic-name"
+                },
+                "repo_link": {
+                    "title": "Link to the repository where the component is maintained (informational)",
+                    "type": "string",
+                    "format": "uri"
+                }
+            }
+        },
+
+        "data-store": {
+            "type": "object",
+            "required": [
+                "symbolic_name",
+                "title",
+                "description",
+                "type"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "symbolic_name": {
+                    "title": "Symbolic name of the data store",
+                    "$ref": "#/$defs/symbolic-name"
+                },
+                "title": {
+                    "title": "Title of the data store",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description of the data store and its purpose",
+                    "type": "string"
+                },
+                "type": {
+                    "title": "Type of data store",
+                    "$ref": "#/$defs/data-store-type"
+                },
+                "vendor": {
+                    "title": "Vendor of the data store product",
+                    "type": "string"
+                },
+                "product": {
+                    "title": "Product implementing the data store",
+                    "type": "string"
+                }
+            }
+        },
+
+        "data-set": {
+            "type": "object",
+            "required": [
+                "symbolic_name",
+                "title",
+                "description",
+                "placements",
+                "data_sensitivity"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "symbolic_name": {
+                    "title": "Symbolic name of the data set",
+                    "$ref": "#/$defs/symbolic-name"
+                },
+                "title": {
+                    "title": "Title of the data set",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description of the data set and its purpose",
+                    "type": "string"
+                },
+                "placements": {
+                    "type": "array",
+                    "items": {
+                        "title": "Placement of the data set on a certain data store",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "data_store": {
+                                "title": "Symbolic name of the data store where the data set is placed",
+                                "$ref": "#/$defs/symbolic-name"
+                            },
+                            "encrypted": {
+                                "title": "Whether the data set is encrypted on this store",
+                                "type": "boolean"
+                            }
+                        }
+                    }
+                },
+                "data_sensitivity": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/data-sensitivity"
+                    }
+                },
+                "access_control_method": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/access_control_method"
+                    }
+                },
+                "record_count": {
+                    "title": "Estimated number of records in the data set",
+                    "type": "integer"
+                }
+            }
+        },
+
+        "data-flow": {
+            "type": "object",
+            "required": [
+                "symbolic_name",
+                "title",
+                "description",
+                "source",
+                "destination",
+                "has_sensitive_data",
+                "encrypted"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "symbolic_name": {
+                    "title": "Symbolic name of the data flow",
+                    "$ref": "#/$defs/symbolic-name"
+                },
+                "title": {
+                    "title": "Title of the data flow",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description of the data flow and its purpose",
+                    "type": "string"
+                },
+                "source": {
+                    "title": "Symbolic name of the source component of the data flow",
+                    "$ref": "#/$defs/typed-symbolic-name"
+                },
+                "destination": {
+                    "title": "Symbolic name of the destination component of the data flow",
+                    "$ref": "#/$defs/typed-symbolic-name"
+                },
+                "has_sensitive_data": {
+                    "title": "Whether the data flow includes sensitive data",
+                    "type": "boolean"
+                },
+                "encrypted": {
+                    "title": "Whether the data flow is encrypted",
+                    "type": "boolean"
+                }
+            }
+        },
+
+        "assumption": {
+            "type": "object",
+            "required": [
+                "description",
+                "validity"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "description": {
+                    "title": "Statement of the assumption",
+                    "type": "string"
+                },
+                "topics": {
+                    "title": "Topics covered by the assumption",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/symbolic-name"
+                    }
+                },
+                "validity": {
+                    "title": "Validity of the assumption",
+                    "enum": ["assumed", "confirmed", "rejected"],
+                    "default": "assumed"
+                }
+            }
+        },
+
+        "threat-persona": {
+            "type": "object",
+            "required": [
+                "symbolic_name",
+                "title",
+                "description",
+                "is_person",
+                "skill_level",
+                "access_level",
+                "malicious_intent",
+                "applicability_to_org"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "symbolic_name": {
+                    "title": "Symbolic name of the threat persona",
+                    "$ref": "#/$defs/symbolic-name"
+                },
+                "title": {
+                    "title": "Name of the person or system posing a threat",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description of the threat persona",
+                    "type": "string"
+                },
+                "is_person": {
+                    "title": "Whether the threat persona is a person or an automated system",
+                    "type": "boolean"
+                },
+                "skill_level": {
+                    "title": "Skill and knowledge level of the threat persona",
+                    "$ref": "#/$defs/attacker-skill-and-knowledge"
+                },
+                "access_level": {
+                    "title": "Access level of the threat persona",
+                    "$ref": "#/$defs/access-level"
+                },
+                "malicious_intent": {
+                    "title": "Whether the threat persona has malicious intent",
+                    "type": "boolean"
+                },
+                "applicability_to_org": {
+                    "title": "Likelihood for the threat persona to attack the organization",
+                    "$ref": "#/$defs/degree"
+                }
+            }
+        },
+
+        "threat": {
+            "type": "object",
+            "required": [
+                "symbolic_name",
+                "title",
+                "description",
+                "threat_persona",
+                "event",
+                "sources"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "symbolic_name": {
+                    "title": "Symbolic name of the threat",
+                    "$ref": "#/$defs/symbolic-name"
+                },
+                "title": {
+                    "title": "Title of the threat",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description of the threat",
+                    "type": "string"
+                },
+                "threat_persona": {
+                    "title": "Symbolic name of the threat persona",
+                    "$ref": "#/$defs/symbolic-name"
+                },
+                "event": {
+                    "title": "Event that triggers the threat",
+                    "type": "string"
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "$comment": "https://nvlpubs.nist.gov/nistpubs/legacy/sp/nistspecialpublication800-30r1.pdf",
+                        "enum": ["adversary", "human_error", "failure", "events_beyond_org_control"]
+                    }
+                },
+                "attack_mechanism": {
+                    "title": "Attack mechanism per CAPEC taxonomy",
+                    "$ref": "#/$defs/capec-ref"
+                },
+                "vulnerabilities": {
+                    "type": "array",
+                    "items": {
+                        "title": "Vulnerability factoring into the threat per CWE taxonomy",
+                        "$ref": "#/$defs/cwe-ref"
+                    }
+                }
+            }
+        },
+
+        "mitigations": {
+            "type": "object",
+            "required": [
+                "symbolic_name",
+                "title",
+                "description",
+                "threats",
+                "status",
+                "priority"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "symbolic_name": {
+                    "title": "Symbolic name of the mitigation",
+                    "$ref": "#/$defs/symbolic-name"
+                },
+                "title": {
+                    "title": "Title of the mitigation",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description of the mitigation",
+                    "type": "string"
+                },
+                "threats": {
+                    "type": "array",
+                    "items": {
+                        "title": "Symbolic name of the threat addressed by the mitigation",
+                        "$ref": "#/$defs/symbolic-name"
+                    }
+                },
+                "trust_boundary": {
+                    "title": "Trust boundary that the mitigation protects, if any",
+                    "$ref": "#/$defs/trust-boundary-ref"
+                },
+                "status": {
+                    "$ref": "#/$defs/mitigation-status"
+                },
+                "priority": {
+                    "$ref": "#/$defs/priority"
+                }
+            }
+        },
+
+        "risk": {
+            "type": "object",
+            "required": [
+                "symbolic_name",
+                "title",
+                "description",
+                "threats",
+                "likelihood",
+                "impact",
+                "impact_description",
+                "score",
+                "level"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "symbolic_name": {
+                    "title": "Symbolic name of the risk",
+                    "$ref": "#/$defs/symbolic-name"
+                },
+                "title": {
+                    "title": "Title of the risk",
+                    "type": "string"
+                },
+                "description": {
+                    "title": "Description of the risk",
+                    "type": "string"
+                },
+                "threats": {
+                    "type": "array",
+                    "items": {
+                        "title": "Symbolic name of threat factoring into the risk",
+                        "$ref": "#/$defs/symbolic-name"
+                    }
+                },
+                "likelihood": {
+                    "title": "Likelihood of the risk materializing",
+                    "$ref": "#/$defs/likelihood"
+                },
+                "impact": {
+                    "title": "Degree of the impact of the risk materializing",
+                    "$ref": "#/$defs/impact"
+                },
+                "impact_description": {
+                    "title": "Description of the impact of the risk materializing",
+                    "type": "string"
+                },
+                "score": {
+                    "title": "Risk score based on likelihood and impact",
+                    "$comment": "http://go/threat-modeling-risk-score",
+                    "$ref": "#/$defs/risk-score"
+                },
+                "level": {
+                    "title": "Risk level band",
+                    "$comment": "http://go/threat-modeling-risk-score",
+                    "type": "string"
+                }
+            }
+        },
+
+        "mitigation-plan": {
+            "title": "Mitigation plan for a particular risk",
+            "description": "Mitigation plan consisting of a set of implementation tasks to mitigate a particular risk. Currently the only type of implementation task supported is security mitigations.",
+            "type": "object",
+            "required": [
+                "risk",
+                "mitigations"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "risk": {
+                    "title": "Risk addressed by the mitigation plan",
+                    "$ref": "#/$defs/symbolic-name"
+                },
+                "mitigations": {
+                    "type": "array",
+                    "items": {
+                        "title": "Security mitigation chosen for implementation to mitigate the risk",
+                        "$ref": "#/$defs/symbolic-name"
+                    }
+                }
+            }
+        }
+    },
+
+    "type": "object",
+    "required": [
+        "version",
+        "target",
+        "trust_zones",
+        "trust_boundaries",
+        "actors",
+        "components",
+        "data_store",
+        "data_sets",
+        "data_flows"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "$schema": {
+            "title": "URI of JSON schema",
+            "const": "https://github.com/OWASP/www-project-threat-model-library/blob/main/threat-model-schema.json"
+        },
+
+        "version": {
+            "title": "Version of the threat model or security review",
+            "$ref": "#/$defs/version"
+        },
+
+        "target": {
+            "title": "Scope of the threat model or security review",
+            "$ref": "#/$defs/target"
+        },
+
+        "description": {
+            "title": "Comprehensive description of the application or service",
+            "description": "Free-form description of the application or service, including its business context and other unstructured information",
+            "type": "string"
+        },
+
+        "frozen": {
+            "title": "Whether the threat model or security review is frozen",
+            "description": "A frozen threat model or security review should not be updated or modified. If modifications are needed, a new version should be created.",
+            "type": "boolean",
+            "default": false
+        },
+        "released_at": {
+            "title": "The time the threat model or security review was released (and frozen), if so",
+            "$ref": "#/$defs/date-or-datetime"
+        },
+        "product_release_date": {
+            "title": "The time of the product release that includes the modeled features or changes",
+            "$ref": "#/$defs/date-or-datetime"
+        },
+        "release_docs_link": {
+            "title": "Link to documentation of the application or service release targeted by the threat model or security review",
+            "type": "string",
+            "format": "uri"
+        },
+        "reviewed_at": {
+            "title": "The time the threat model or security review was last reviewed",
+            "$ref": "#/$defs/date-or-datetime"
+        },
+        "repo_link": {
+            "title": "Link to the main repository associated with the application or service",
+            "type": "string",
+            "format": "uri"
+        },
+
+        "diagrams": {
+            "type": "array",
+            "items": {
+                "title": "Diagram of the application or service",
+                "$ref": "#/$defs/diagram"
+            }
+        },
+
+        "trust_zones": {
+            "type": "array",
+            "items": {
+                "title": "Trust zone of the application or service",
+                "$ref": "#/$defs/trust-zone"
+            }
+        },
+
+        "trust_boundaries": {
+            "type": "array",
+            "items": {
+                "title": "Boundary between two trust zones of the application or service",
+                "$ref": "#/$defs/trust-boundary"
+            }
+        },
+
+        "actors": {
+            "type": "array",
+            "items": {
+                "title": "External entity that interacts with the application or service",
+                "$ref": "#/$defs/actor"
+            }
+        },
+
+        "components": {
+            "type": "array",
+            "items": {
+                "title": "Component of the application or service",
+                "$ref": "#/$defs/component"
+            }
+        },
+
+        "data_store": {
+            "type": "array",
+            "items": {
+                "title": "Data store used by the application or service",
+                "$ref": "#/$defs/data-store"
+            }
+        },
+
+        "data_sets": {
+            "type": "array",
+            "items": {
+                "title": "Data set used by the application or service",
+                "$ref": "#/$defs/data-set"
+            }
+        },
+
+        "data_flows": {
+            "type": "array",
+            "items": {
+                "title": "Data flow between components of the application or service",
+                "$ref": "#/$defs/data-flow"
+            }
+        },
+
+        "vulnerabilities": {
+            "type": "array",
+            "items": {
+                "title": "Vulnerability identified in the application or service",
+                "$ref": "#/$defs/vulnerability"
+            }
+        },
+
+        "output": {
+            "type": "object",
+            "required": [
+                "assumptions",
+                "threat_personas",
+                "threats",
+                "mitigations",
+                "risks"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "assumptions": {
+                    "type": "array",
+                    "items": {
+                        "title": "Assumption inferred about the application or service",
+                        "$ref": "#/$defs/assumption"
+                    }
+                },
+
+                "threat_personas": {
+                    "type": "array",
+                    "items": {
+                        "title": "Threat persona that poses a threat to the application or service",
+                        "$ref": "#/$defs/threat-persona"
+                    }
+                },
+
+                "threats": {
+                    "type": "array",
+                    "items": {
+                        "title": "Threat identified in the application or service",
+                        "$ref": "#/$defs/threat"
+                    }
+                },
+
+                "mitigations": {
+                    "type": "array",
+                    "items": {
+                        "title": "Security mitigation to address specific threats to the application or service",
+                        "$ref": "#/$defs/mitigations"
+                    }
+                },
+
+                "attributes": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["attribute", "value"],
+                        "properties": {
+                            "attribute": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+
+                "risks": {
+                    "type": "array",
+                    "items": {
+                        "title": "Risk identified in the application or service",
+                        "$ref": "#/$defs/risk"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/threat-model.schema.json
+++ b/threat-model.schema.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/OWASP/www-project-threat-model-library/blob/main/threat-model-schema.json",
     "$comment": "When updating the schema `$id`, also update the value of the constant `$schema` property below.",
-    "title": "Threat-model-library-schema",
+    "title": "OWASP Threat Model Library Schema",
 
     "$defs": {
         "version": {
@@ -17,7 +17,7 @@
             "pattern": "^[0-9a-z-]+$"
         },
         "typed-symbolic-name": {
-            "title": "Symbolic name of an object of a specified type",
+            "title": "Symbolic name reference to an object of a specified type",
             "type": "object",
             "required": ["type", "name"],
             "additionalProperties": false,
@@ -27,7 +27,7 @@
                     "description": "The type of the object being referenced, as a '#/$defs/...' or simple '...' type reference.",
                     "type": "string"
                 },
-                "name": {
+                "object": {
                     "$ref": "#/$defs/symbolic-name"
                 }
             }
@@ -50,11 +50,11 @@
         "business-criticality": {
             "$ref": "#/$defs/degree"
         },
-        "mitigation-status": {
+        "control-status": {
             "enum": ["assumed", "active", "suggested", "under_review", "approved", "scheduled", "retired", "wont_do"]
         },
         "data-sensitivity": {
-            "enum": ["pii", "phi", "fin", "ip", "cred", "biz", "gov", "pci"]
+            "enum": ["pii", "phi", "fin", "ip", "cred", "biz", "gov", "pci", "op"]
         },
         "degree": {
             "enum": ["minimal", "low", "moderate", "high", "maximal"]
@@ -77,18 +77,17 @@
             "maximum": 25
         },
         "tier": {
-            "enum": ["1_mission_critical", "2_business_critical", "3_important", "4_non_critical"]
+            "enum": ["mission_critical", "business_critical", "important", "non_critical"]
         },
-        
 
         "access-level": {
             "enum": ["anonymous", "user", "admin"]
         },
-        "access_control_method": {
-            "enum": ["acl", "rbac", "mac", "dac", "abac"]
+        "access-control-method": {
+            "enum": ["none", "acl", "rbac", "mac", "dac", "abac"]
         },
         "authentication-method": {
-            "enum": ["password", "otp", "public_key", "token", "biometrics", "sso", "social"]
+            "enum": ["none", "password", "otp", "challenge_response", "public_key", "token", "biometrics", "sso", "social"]
         },
 
         "data-store-type": {
@@ -140,7 +139,7 @@
             "enum": ["script_kid", "insider", "engineer", "expert_engineer", "oc_sponsored", "state_sponsored"]
         },
 
-        "target": {
+        "scope": {
             "type": "object",
             "required": [
                 "title",
@@ -153,11 +152,11 @@
             "additionalProperties": false,
             "properties": {
                 "title": {
-                    "title": "Short description of the target of this threat model of an application or service",
+                    "title": "Short description of the scope of the threat model",
                     "type": "string"
                 },
                 "description": {
-                    "title": "Definition of the target of an application or service",
+                    "title": "Definition of the scope of an application or service",
                     "type": "string"
                 },
                 "business_criticality": {
@@ -252,15 +251,15 @@
                     "title": "Symbolic name of the second trust zone",
                     "$ref": "#/$defs/symbolic-name"
                 },
-                "access_control_method": {
-                    "title": "Access control method used between the two trust zones",
+                "access_control_methods": {
+                    "title": "Access control methods used between the two trust zones",
                     "type": "array",
                     "items": {
-                        "$ref": "#/$defs/access_control_method"
+                        "$ref": "#/$defs/access-control-method"
                     }
                 },
-                "authentication_method": {
-                    "title": "Authentication method used between the two trust zones",
+                "authentication_methods": {
+                    "title": "Authentication methods used between the two trust zones",
                     "type": "array",
                     "items": {
                         "$ref": "#/$defs/authentication-method"
@@ -440,7 +439,7 @@
                                 "$ref": "#/$defs/symbolic-name"
                             },
                             "encrypted": {
-                                "title": "Whether the data set is encrypted on this store",
+                                "title": "Whether the data set is encrypted on this data store",
                                 "type": "boolean"
                             }
                         }
@@ -452,10 +451,10 @@
                         "$ref": "#/$defs/data-sensitivity"
                     }
                 },
-                "access_control_method": {
+                "access_control_methods": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/$defs/access_control_method"
+                        "$ref": "#/$defs/access-control-method"
                     }
                 },
                 "record_count": {
@@ -530,8 +529,8 @@
                 },
                 "validity": {
                     "title": "Validity of the assumption",
-                    "enum": ["assumed", "confirmed", "rejected"],
-                    "default": "assumed"
+                    "enum": ["unconfirmed", "confirmed", "rejected"],
+                    "default": "unconfirmed"
                 }
             }
         },
@@ -609,6 +608,13 @@
                     "title": "Description of the threat",
                     "type": "string"
                 },
+                "components_affected": {
+                    "title": "Components affected by the threat",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/symbolic-name"
+                    }
+                },
                 "threat_persona": {
                     "title": "Symbolic name of the threat persona",
                     "$ref": "#/$defs/symbolic-name"
@@ -624,21 +630,23 @@
                         "enum": ["adversary", "human_error", "failure", "events_beyond_org_control"]
                     }
                 },
-                "attack_mechanism": {
-                    "title": "Attack mechanism per CAPEC taxonomy",
-                    "$ref": "#/$defs/capec-ref"
+                "attack_mechanisms": {
+                    "items": {
+                        "title": "Attack mechanism per CAPEC taxonomy",
+                        "$ref": "#/$defs/capec-ref"
+                    }
                 },
-                "vulnerabilities": {
+                "weaknesses": {
                     "type": "array",
                     "items": {
-                        "title": "Vulnerability factoring into the threat per CWE taxonomy",
+                        "title": "Weakness factoring into the threat per CWE taxonomy",
                         "$ref": "#/$defs/cwe-ref"
                     }
                 }
             }
         },
 
-        "mitigations": {
+        "control": {
             "type": "object",
             "required": [
                 "symbolic_name",
@@ -651,30 +659,30 @@
             "additionalProperties": false,
             "properties": {
                 "symbolic_name": {
-                    "title": "Symbolic name of the mitigation",
+                    "title": "Symbolic name of the control",
                     "$ref": "#/$defs/symbolic-name"
                 },
                 "title": {
-                    "title": "Title of the mitigation",
+                    "title": "Title of the control",
                     "type": "string"
                 },
                 "description": {
-                    "title": "Description of the mitigation",
+                    "title": "Description of the control",
                     "type": "string"
                 },
                 "threats": {
                     "type": "array",
                     "items": {
-                        "title": "Symbolic name of the threat addressed by the mitigation",
+                        "title": "Symbolic name of the threat addressed by the control",
                         "$ref": "#/$defs/symbolic-name"
                     }
                 },
                 "trust_boundary": {
-                    "title": "Trust boundary that the mitigation protects, if any",
+                    "title": "Trust boundary that the control protects, if any",
                     "$ref": "#/$defs/trust-boundary-ref"
                 },
                 "status": {
-                    "$ref": "#/$defs/mitigation-status"
+                    "$ref": "#/$defs/control-status"
                 },
                 "priority": {
                     "$ref": "#/$defs/priority"
@@ -743,11 +751,11 @@
 
         "mitigation-plan": {
             "title": "Mitigation plan for a particular risk",
-            "description": "Mitigation plan consisting of a set of implementation tasks to mitigate a particular risk. Currently the only type of implementation task supported is security mitigations.",
+            "description": "Mitigation plan consisting of a set of implementation tasks to mitigate a particular risk. Currently the only type of implementation task supported is security controls.",
             "type": "object",
             "required": [
                 "risk",
-                "mitigations"
+                "controls"
             ],
             "additionalProperties": false,
             "properties": {
@@ -755,10 +763,10 @@
                     "title": "Risk addressed by the mitigation plan",
                     "$ref": "#/$defs/symbolic-name"
                 },
-                "mitigations": {
+                "controls": {
                     "type": "array",
                     "items": {
-                        "title": "Security mitigation chosen for implementation to mitigate the risk",
+                        "title": "Security control chosen for implementation to mitigate the risk",
                         "$ref": "#/$defs/symbolic-name"
                     }
                 }
@@ -769,12 +777,12 @@
     "type": "object",
     "required": [
         "version",
-        "target",
+        "scope",
         "trust_zones",
         "trust_boundaries",
         "actors",
         "components",
-        "data_store",
+        "data_stores",
         "data_sets",
         "data_flows"
     ],
@@ -782,7 +790,7 @@
     "properties": {
         "$schema": {
             "title": "URI of JSON schema",
-            "const": "https://github.com/OWASP/www-project-threat-model-library/blob/main/threat-model-schema.json"
+            "const": "https://github.com/OWASP/www-project-threat-model-library/blob/main/threat-model.schema.json"
         },
 
         "version": {
@@ -790,9 +798,9 @@
             "$ref": "#/$defs/version"
         },
 
-        "target": {
+        "scope": {
             "title": "Scope of the threat model or security review",
-            "$ref": "#/$defs/target"
+            "$ref": "#/$defs/scope"
         },
 
         "description": {
@@ -870,7 +878,7 @@
             }
         },
 
-        "data_store": {
+        "data_stores": {
             "type": "array",
             "items": {
                 "title": "Data store used by the application or service",
@@ -902,72 +910,53 @@
             }
         },
 
-        "output": {
+        "assumptions": {
+            "type": "array",
+            "items": {
+                "title": "Assumption inferred about the application or service",
+                "$ref": "#/$defs/assumption"
+            }
+        },
+
+        "threat_personas": {
+            "type": "array",
+            "items": {
+                "title": "Threat persona that poses a threat to the application or service",
+                "$ref": "#/$defs/threat-persona"
+            }
+        },
+
+        "threats": {
+            "type": "array",
+            "items": {
+                "title": "Threat identified in the application or service",
+                "$ref": "#/$defs/threat"
+            }
+        },
+
+        "controls": {
+            "type": "array",
+            "items": {
+                "title": "Security control to address specific threats to the application or service",
+                "$ref": "#/$defs/control"
+            }
+        },
+
+        "risks": {
+            "type": "array",
+            "items": {
+                "title": "Risk identified in the application or service",
+                "$ref": "#/$defs/risk"
+            }
+        },
+
+        "extensions": {
+            "title": "Non-standard information",
+            "description": "Additional non-standard information that may be relevant. Each property must be named like a domain name followed by a slash and a URL path; this may or may not be a requestable URL (with an assumed scheme of 'http', providing documentation on the structure and semantics of the extension) but must be globally unique.",
             "type": "object",
-            "required": [
-                "assumptions",
-                "threat_personas",
-                "threats",
-                "mitigations",
-                "risks"
-            ],
             "additionalProperties": false,
-            "properties": {
-                "assumptions": {
-                    "type": "array",
-                    "items": {
-                        "title": "Assumption inferred about the application or service",
-                        "$ref": "#/$defs/assumption"
-                    }
-                },
-
-                "threat_personas": {
-                    "type": "array",
-                    "items": {
-                        "title": "Threat persona that poses a threat to the application or service",
-                        "$ref": "#/$defs/threat-persona"
-                    }
-                },
-
-                "threats": {
-                    "type": "array",
-                    "items": {
-                        "title": "Threat identified in the application or service",
-                        "$ref": "#/$defs/threat"
-                    }
-                },
-
-                "mitigations": {
-                    "type": "array",
-                    "items": {
-                        "title": "Security mitigation to address specific threats to the application or service",
-                        "$ref": "#/$defs/mitigations"
-                    }
-                },
-
-                "attributes": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "required": ["attribute", "value"],
-                        "properties": {
-                            "attribute": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-
-                "risks": {
-                    "type": "array",
-                    "items": {
-                        "title": "Risk identified in the application or service",
-                        "$ref": "#/$defs/risk"
-                    }
-                }
+            "patternProperties": {
+                "^([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\\.)+[A-Za-z]+(/[-$%'()*+,.:;=@^_~0-9A-Za-z]+)+$": {}
             }
         }
     }

--- a/threat-models/husky-ai-threat-model.json
+++ b/threat-models/husky-ai-threat-model.json
@@ -1,0 +1,1014 @@
+{
+    "$schema": "https://github.com/OWASP/www-project-threat-model-library/blob/main/threat-model-schema.json",
+    "version": "1.0",
+    "target": {
+      "title": "Husky AI",
+      "description": "A machine learning system to classify Huskies vs dogs. HuskyAI is a machine learning system designed to classify images and distinguish between huskies and non-huskies. It integrates secure data handling practices with a robust convolutional neural network (CNN) for image recognition. Secure Image Retrieval: HuskyAI uses TLS to securely fetch images from Azure Cognitive Services, ensuring encryption during data transmission and validating the server's authenticity to prevent man-in-the-middle attacks. Data Storage and Access Controls: Azure Blob Storage is used to store datasets, with public access fully blocked. Access is controlled using Role-Based Access Control (rbac) and Attribute-Based Access Control (ABAC) to enforce granular, identity-based permissions. Jupyter Notebooks, which host model development and experimentation, are also secured with rbac and ABAC, preventing unauthorized public access. Developer Authentication: Developers access the system through SSH keys protected by passphrases. This adds an additional layer of security, reducing the likelihood of unauthorized access even if keys are exposed. Model and Dataset Dataset Composition: The dataset comprises approximately 1,300 husky images and 3,000 non-husky images sourced via Bing's image search. Data undergoes manual cleansing and is split into training and validation sets to enhance model performance. Model Design: HuskyAI employs a CNN with: Convolutional layers for feature extraction. Max-pooling layers for dimensionality reduction. Dropout layers to prevent overfitting. Dense layers for final classification. The model is trained with the Adam optimizer and a learning rate of 0.0005, optimized for accuracy and computational efficiency. Security Considerations rbac and ABAC controls across storage and development environments ensure sensitive data and configurations are protected. TLS ensures secure communication channels, preventing eavesdropping or data interception during image retrieval. Applications HuskyAI is tailored for accurate image classification and can be adapted for other domains requiring precise visual differentiation, with a focus on maintaining strong security postures. HuskyAI combines state-of-the-art machine learning techniques with stringent security controls, including secure communications, robust access management, and encrypted developer authentication, to deliver a reliable and secure image classification system.",
+      "business_criticality": "low",
+      "data_sensitivity": ["biz"],
+      "exposure": "external",
+      "tier": "4_non_critical"
+    },
+    "description": "A machine learning system to classify Huskies vs dogs",
+    "frozen": false,
+    "release_docs_link": "https://github.com/wunderwuzzi23/huskyai",
+    "reviewed_at": "2024-11-15",
+    "next_review_by": "2025-01-10",
+    "repo_link": "https://github.com/wunderwuzzi23/huskyai",
+    "diagrams": [
+        {
+            "title": "System architecture",
+            "type": "plantuml",
+            "source": "@startuml ' External Entities card \"Azure Cognitive Services\" as ext1 card \"Third Party tools and ML libraries\" as ext5 actor \"User\" as ext2 actor \"Engineer\" as ext4 actor \"Infrastructure Admin\" as ext3 card \"Third Party tools and ML libraries\" as ext7 ' Package for Experimentation Boundary package \"Experimentation\" { ' Data Stores (Cylinders for storage) storage \"Training and Validation Images\" as ds1 storage \"API Key\" as ds2 storage \"Machine Learning Model\" as ds3 storage \"Source Code and Configuration\" as ds5 ' Processes (Circles for processes using skinparam) rectangle \"Gather Images Application - Python\" as p1 rectangle \"Jupyter Notebook\" as p2 rectangle \"Deployment\" as p3 ' Apply circle styling to processes skinparam rectangle { roundCorner 100 } ' Data Flows in Experimentation ext1 <--> p1 : Send Images via HTTPS ext5 --> p1 : imports ext5 --> p2 : imports ext4 --> p1 : VS Code (SSH) ext4 --> p2 : VS Code (SSH) ext4 --> p3 : SSH ext4 --> ds5 : stores (SSH) p1 --> ds1 : Store Images ds2 --> p1 : Loads ds1 <--> p2 : Processes p1 --> p2 : Processed Data p2 --> ds3 : Save Model as .h5 ds3 --> p3 : Package Model ds5 --> p3 : Source Code and Config via SSH } ' Package for Production Boundary package \"Production\" { ' Data Stores (Cylinders for storage) storage \"Stored Machine Learning Model\" as ds6 storage \"Bastion Logs\" as ds7 storage \"Authorized Keys\" as ds8 ' Processes (Circles for processes using skinparam) rectangle \"API Gateway\" as p4 rectangle \"Bastion\" as p5 rectangle \"Simple Python Web Server\" as p6 ' Data Flows in Production ext2 <--> p4 : Request via HTTPS p5 --> p4 : update p4 <--> p6 : HTTPS p5 --> p6 : update ds6 --> p6 : Load Model p3 --> p5 : SSH p5 --> ds7 : Update Logs ext3 --> p5 : SSH p5 --> ds6 : update ds8 --> p5 : Provide Access ext7 --> p6 : imports } @enduml"
+        }
+    ],
+    "trust_zones": [
+        {
+            "symbolic_name": "prod-zone",
+            "title": "Production Trust Zone",
+            "description": "Internal VPC with the production deployment of HuskyAI"
+        },
+        {
+            "symbolic_name": "experimental-zone",
+            "title": "Experimental Trust Zone",
+            "description": "Internal VPC with the production deployment of HuskyAI"
+        },
+        {
+            "symbolic_name": "public",
+            "title": "Public Internet",
+            "description": "The public internet"
+        }
+    ],
+    "trust_boundaries": [
+        {
+            "trust_zone_a": "prod-zone",
+            "trust_zone_b": "experimental-zone",
+            "access_control_method": ["rbac", "acl"],
+            "authentication_method": ["public_key"]
+        },
+        {
+            "trust_zone_a": "public",
+            "trust_zone_b": "experimental-zone",
+            "access_control_method": ["rbac", "acl"],
+            "authentication_method": ["password", "password"]
+        },
+        {
+            "trust_zone_a": "public",
+            "trust_zone_b": "prod-zone",
+            "access_control_method": ["rbac", "acl"],
+            "authentication_method": ["sso"]
+        }
+    ],
+    "actors": [
+        {
+            "symbolic_name": "engineer",
+            "title": "Data Engineer",
+            "description": "An engineer responsible for building, training, and deploying machine learning models.",
+            "type": "engineer",
+            "permissions": "Develop and deploy machine learning models; interact with Experimentation tools such as Jupyter Notebook."
+        },
+        {
+            "symbolic_name": "infrastructure-admin",
+            "title": "Azure Platform Engineer",
+            "description": "Administrator responsible for securing and maintaining production infrastructure.",
+            "type": "administrator",
+            "permissions": "Manage production infrastructure; control access via the Bastion; monitor logs and update keys."
+        },
+        {
+            "symbolic_name": "azure-cognitive-services",
+            "title": "Azure Cognitive Services",
+            "description": "External service providing resources for machine learning experimentation.",
+            "type": "third_party",
+            "permissions": "Provide images for training and validation through an external service."
+        },
+        {
+            "symbolic_name": "third-party-tools",
+            "title": "Third party tools",
+            "description": "External third party tools for the services",
+            "type": "third_party",
+            "permissions": "No direct permissions works on pull"
+        }
+    ],
+
+    "components": [
+        {
+            "symbolic_name": "web-service",
+            "title": "Simple Python Web Server",
+            "description": "Serves as simple web server",
+            "trust_zone": "prod-zone",
+            "repo_link": "https://github.com/wunderwuzzi23/huskyai"
+        },
+        {
+            "symbolic_name": "api-gateway",
+            "title": "API Gateway",
+            "description": "Serves as the entry point for external users to interact with the production environment via HTTPS. It routes user requests to the Simple Python Web Server and ensures secure communication. The API Gateway enforces request validation and manages APIs exposed to the public while ensuring access control to internal services.",
+            "trust_zone": "prod-zone",
+            "repo_link": "https://github.com/wunderwuzzi23/huskyai"
+        },
+        {
+            "symbolic_name": "bastion",
+            "title": "Bastion Server",
+            "description": "A secure access management component for administrative functions. It provides controlled SSH access for the Infrastructure Admin to internal production resources, such as the Stored Machine Learning Model and Simple Python Web Server.",
+            "trust_zone": "prod-zone",
+            "repo_link": "https://github.com/wunderwuzzi23/huskyai"
+        },
+        {
+            "symbolic_name": "gather-images",
+            "title": "Gather Images Application - Python",
+            "description": "This is a Python-based application responsible for gathering images from external sources, specifically Azure Cognitive Services, and storing them in the designated Training and Validation Images storage. ",
+            "trust_zone": "experimental-zone",
+            "repo_link": "https://github.com/wunderwuzzi23/huskyai"
+        },
+        {
+            "symbolic_name": "jupyter",
+            "title": "Jupyter Notebook",
+            "description": "A Jupyter Notebook environment that processes the images stored in Training and Validation Images, executes code using external ML libraries, and provides a UI for engineers to interact with and manipulate data, allowing for iterative model development. It can save trained machine learning models to Machine Learning Model storage.",
+            "trust_zone": "experimental-zone",
+            "repo_link": "https://github.com/wunderwuzzi23/huskyai"
+        },
+        {
+            "symbolic_name": "deployment-service",
+            "title": "Deployment Service",
+            "description": "Handles the deployment of the machine learning model by packaging the model and all necessary source code and configuration stored in Source Code and Configuration. It receives the final model from Jupyter Notebook and prepares it for deployment to the production environment.",
+            "trust_zone": "experimental-zone",
+            "repo_link": "https://github.com/wunderwuzzi23/huskyai"
+        }
+    ],
+
+    "data_store": [
+        {
+            "symbolic_name": "training-images-blob",
+            "title": "Training And Validation Images Storage Blob",
+            "description": "Contains images used for training and validation of machine learning models.",
+            "type": "object",
+            "vendor": "Azure",
+            "product": "Blob"
+        },
+        {
+            "symbolic_name": "api-key-storage",
+            "title": "API Key Storage",
+            "description": "Stores API keys for secure access to external services.",
+            "type": "key_value",
+            "vendor": "Azure",
+            "product": "Key Vault"
+        },
+        {
+            "symbolic_name": "secret-key-storage",
+            "title": "Authorized Keys Storage",
+            "description": "Contains SSH keys used for securing administrative access.",
+            "type": "key_value",
+            "vendor": "Azure",
+            "product": "Key Vault"
+        },
+        {
+            "symbolic_name": "ml-models-blob",
+            "title": "Machine Learning Model Storage Blob",
+            "description": "Contains storage for machine learning models in serialized format.",
+            "type": "object",
+            "vendor": "Azure",
+            "product": "Blob"
+        },
+        {
+            "symbolic_name": "source-code-config-storage",
+            "title": "Source Code And Configuration Storage",
+            "description": "Stores source code and configuration files for deployment and production setup.",
+            "type": "object",
+            "vendor": "GitHub",
+            "product": "GitHub Repositories"
+        },
+        {
+            "symbolic_name": "bastion-logs-storage",
+            "title": "Bastion Logs Storage",
+            "description": "Contains logs related to SSH access and activity through the Bastion.",
+            "type": "object",
+            "vendor": "Azure",
+            "product": "Azure Monitor"
+        },
+        {
+            "symbolic_name": "uploaded-images-redis",
+            "title": "Azure Cache for Redis",
+            "description": "Provides an in-memory data structure store for caching and message brokering.",
+            "type": "object",
+            "vendor": "Azure",
+            "product": "Azure Cache for Redis"
+        }
+    ],
+    "data_sets": [
+        {
+            "symbolic_name": "training-images",
+            "title": "Training and Validation Images",
+            "description":  "Contains images used for training and validation of machine learning models.",
+            "placements": [
+                {
+                    "data_store": "training-images-blob",
+                    "encrypted": true
+                }
+            ],
+            "record_count": 100000,
+            "data_sensitivity": ["biz"],
+            "access_control_method": ["rbac"]
+        },
+        {
+            "symbolic_name": "api-keys",
+            "title": "API Keys",
+            "description": "Stores API keys for secure access to external services.",
+            "placements": [
+                {
+                    "data_store": "api-keys-blob",
+                    "encrypted": true
+                }
+            ],
+            "record_count": 20,
+            "data_sensitivity": ["cred"],
+            "access_control_method": ["rbac"]
+        },
+        {
+            "symbolic_name": "stored-ml-models",
+            "title": "Stored Machine Learning Models",
+            "description": "Contains trained machine learning models in serialized format for production use.",
+            "placements": [
+                {
+                    "data_store": "ml-models-blob",
+                    "encrypted": false
+                }
+            ],
+            "record_count": 10,
+            "data_sensitivity": ["biz"],
+            "access_control_method": ["rbac"]
+        },
+        {
+            "symbolic_name": "source-code-config",
+            "title": "Source Code and Configuration",
+            "description": "Stores source code and configuration files for deployment and production setup.",
+            "placements": [
+                {
+                    "data_store": "source-code-config-storage",
+                    "encrypted": true
+                }
+            ],
+            "record_count": 200,
+            "data_sensitivity": ["biz"],
+            "access_control_method": ["rbac"]
+        },
+        {
+            "symbolic_name": "bastion-logs",
+            "title": "Bastion Logs",
+            "description": "Stores logs related to SSH access and activity through the Bastion.",
+            "placements": [
+                {
+                    "data_store": "bastion-logs-storage",
+                    "encrypted": true
+                }
+            ],
+            "record_count": 5000,
+            "data_sensitivity": ["biz"],
+            "access_control_method": ["acl"]
+        },
+        {
+            "symbolic_name": "authorized-keys",
+            "title": "Authorized Keys",
+            "description": "Contains SSH keys used for securing administrative access.",
+            "placements": [
+                {
+                    "data_store": "secret-keys-storage",
+                    "encrypted": true
+                }
+            ],
+            "record_count": 100,
+            "data_sensitivity": ["cred"],
+            "access_control_method": ["rbac"]
+        },
+        {
+            "symbolic_name": "uploaded-images",
+            "title": "Uploaded Images",
+            "description": "Contains images that users upload to understand if an image is a Husky or not.",
+            "placements": [
+                {
+                    "data_store": "uploaded-images-redis",
+                    "encrypted": false
+                }
+            ],
+            "record_count": 100000000,
+            "data_sensitivity": [],
+            "access_control_method": []
+        }
+    ],
+
+    "data_flows": [
+        {
+            "symbolic_name": "azure-cognitive-gather-images",
+            "title": "Azure Cognitive Services to Gather Images Application",
+            "description": "Transfer data from Azure Cognitive Services to Gather Images Application in Python.",
+            "source": {"type": "actor", "name": "azure-cognitive-services"},
+            "destination": {"type": "component", "name": "gather-images"},
+            "has_sensitive_data": true,
+            "encrypted": true
+        },
+        {
+            "symbolic_name": "third-party-tools-gather-images",
+            "title": "Third Party Tools to Gather Images Application",
+            "description": "Transfer data from Third Party tools and ML libraries to Gather Images Application in Python.",
+            "source": {"type": "actor", "name":"third-party-tools"},
+            "destination": {"type": "component", "name": "gather-images"},
+            "has_sensitive_data": false,
+            "encrypted": true
+        },
+        {
+            "symbolic_name": "third-party-tools-jupyter-notebook",
+            "title": "Third Party Tools to Jupyter Notebook",
+            "description": "Transfer data from Third Party tools and ML libraries to Jupyter Notebook.",
+            "source": {"type": "actor", "name":"third-party-tools"},
+            "destination": {"type": "component", "name": "jupyter"},
+            "has_sensitive_data": false,
+            "encrypted": true
+        },
+        {
+            "symbolic_name": "engineer-gather-images",
+            "title": "Engineer to Gather Images Application",
+            "description": "Transfer data from Engineer to Gather Images Application in Python.",
+            "source": {"type": "actor", "name":"engineer"},
+            "destination": {"type": "component", "name": "gather-images"},
+            "has_sensitive_data": false,
+            "encrypted": true
+        },
+        {
+            "symbolic_name": "engineer-jupyter-notebook",
+            "title": "Engineer to Jupyter Notebook",
+            "description": "Transfer code and ML models from Engineer locally to Jupyter Notebook.",
+            "source": {"type": "actor", "name":"engineer"},
+            "destination": {"type": "component", "name": "jupyter"},
+            "has_sensitive_data": true,
+            "encrypted": true
+        },
+        {
+            "symbolic_name": "gather-images-training-images",
+            "title": "Gather Images to Training and Validation Images",
+            "description": "Transfer images from Gather Images Application to Training and Validation Images.",
+            "source": {"type": "component", "name": "gather-images"},
+            "destination": {"type": "data_store", "name": "training-images-blob"},
+            "has_sensitive_data": true,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "api-key-storage-gather-images",
+            "title": "API Key Storage to Gather Images Application",
+            "description": "API Key Storage to Gather Images Application in Python.",
+            "source": {"type": "data_store", "name":"api-key-storage"},
+            "destination": {"type": "component", "name": "gather-images"},
+            "has_sensitive_data": true,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "training-images-jupyter-notebook",
+            "title": "Training Images to Jupyter Notebook",
+            "description": "Load from Training and Validation Images to Jupyter Notebook.",
+            "source": {"type": "data_store", "name": "training-images-blob"},
+            "destination": {"type": "component", "name": "jupyter"},
+            "has_sensitive_data": true,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "gather-images-jupyter-notebook",
+            "title": "Gather Images Application to Jupyter Notebook",
+            "description": "Transfer data from Gather Images Application to Jupyter Notebook.",
+            "source": {"type": "component", "name": "gather-images"},
+            "destination": {"type": "component", "name": "jupyter"},
+            "has_sensitive_data": false,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "jupyter-notebook-ml-model",
+            "title": "Jupyter Notebook to Machine Learning Model",
+            "description": "Transfer final model from Jupyter Notebook to Machine Learning Model.",
+            "source": {"type": "component", "name": "jupyter"},
+            "destination": {"type": "data_store", "name": "ml-models-blob"},
+            "has_sensitive_data": true,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "ml-model-deployment-service",
+            "title": "Machine Learning Model to Deployment Service",
+            "description": "Transfer from Machine Learning Model Blob to Deployment Service.",
+            "source": {"type": "data_store", "name": "ml-models-blob"},
+            "destination": {"type": "component", "name": "deployment-service"},
+            "has_sensitive_data": true,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "source-code-deployment",
+            "title": "Source Code and Configuration to Deployment",
+            "description": "Transfer data from Source Code and Configuration to Deployment.",
+            "source": {"type": "data_store", "name":"source-code-config-storage"},
+            "destination": {"type": "component", "name": "deployment-service"},
+            "has_sensitive_data": false,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "user-api-gateway",
+            "title": "User to API Gateway",
+            "description": "Transfer from User to API Gateway.",
+            "source": {"type": "actor","name": "user"},
+            "destination": {"type": "component","name": "api-gateway"},
+            "has_sensitive_data": true,
+            "encrypted": true
+        },
+        {
+            "symbolic_name": "bastion-api-gateway",
+            "title": "Bastion to API Gateway",
+            "description": "Transfer data from Bastion to API Gateway.",
+            "source": {"type": "component","name": "bastion"},
+            "destination": {"type": "component","name": "api-gateway"},
+            "has_sensitive_data": false,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "api-gateway-web-server",
+            "title": "API Gateway to Simple Python Web Server",
+            "description": "Transfer data from API Gateway to Simple Python Web Server.",
+            "source": {"type": "component","name": "api-gateway"},
+            "destination": {"type": "component","name": "web-service"},
+            "has_sensitive_data": false,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "bastion-web-server",
+            "title": "Bastion to Simple Python Web Server",
+            "description": "Transfer data from Bastion to Simple Python Web Server.",
+            "source": {"type": "component","name": "bastion"},
+            "destination": {"type": "component","name": "web-service"},
+            "has_sensitive_data": false,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "stored-ml-model-web-server",
+            "title": "Stored Machine Learning Model to Simple Python Web Server",
+            "description": "Transfer sensitive data from Stored Machine Learning Model to Simple Python Web Server.",
+            "source": {"type": "data_store", "name": "ml-models-blob"},
+            "destination": {"type": "component","name": "web-service"},
+            "has_sensitive_data": true,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "deployment-bastion",
+            "title": "Deployment Service to Bastion",
+            "description": "Transfer sensitive data from Deployment Service to Bastion.",
+            "source": {"type": "component", "name": "deployment-service"},
+            "destination": {"type": "component","name": "bastion"},
+            "has_sensitive_data": true,
+            "encrypted": true
+        },
+        {
+            "symbolic_name": "bastion-logs-storage",
+            "title": "Bastion to Bastion Logs Storage",
+            "description": "Transfer sensitive data from Bastion to Bastion Logs Storage.",
+            "source": {"type": "component","name": "bastion"},
+            "destination": {"type": "data_store","name":"bastion-logs-storage"},
+            "has_sensitive_data": true,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "admin-bastion",
+            "title": "Infrastructure Admin to Bastion",
+            "description": "Transfer data from Infrastructure Admin to Bastion.",
+            "source": {"type": "actor", "name":"infrastructure-admin"},
+            "destination": {"type": "component","name": "bastion"},
+            "has_sensitive_data": true,
+            "encrypted": true
+        },
+        {
+            "symbolic_name": "bastion-stored-ml-model",
+            "title": "Bastion to Stored Machine Learning Model",
+            "description": "Transfer sensitive data from Bastion to Stored Machine Learning Model.",
+            "source": {"type": "component","name": "bastion"},
+            "destination": {"type": "data_store", "name": "ml-models-blob"},
+            "has_sensitive_data": true,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "authorized-keys-bastion",
+            "title": "Authorized Keys Storage to Bastion",
+            "description": "Transfer sensitive data from Authorized Keys Storage to Bastion.",
+            "source": {"type": "data_store","name":"secret-keys"},
+            "destination": {"type": "data_store", "name": "bastion"},
+            "has_sensitive_data": true,
+            "encrypted": true
+        },
+        {
+            "symbolic_name": "third-party-tools-web-server",
+            "title": "Third Party Tools to Simple Python Web Server",
+            "description": "Transfer data from Third Party tools and ML libraries to Simple Python Web Server.",
+            "source": {"type": "actor", "name": "third-party-tools"},
+            "destination": {"type": "component", "name": "web-service"},
+            "has_sensitive_data": false,
+            "encrypted": true
+        }
+    ],
+
+    "output": {
+        "assumptions": [
+            {
+                "description": "All services within the trust boundary validate tokens via Auth Service",
+                "validity": "confirmed"
+            }
+        ],
+        "threat_personas": [
+            {
+                "symbolic_name": "ratimir",
+                "title": "Ratimir",
+                "description": "An expert social engineer, great at writing its own exploits and malware - Ratimir is a worthy adversary to consider",
+                "is_person": true,
+                "skill_level": "expert_engineer",
+                "access_level": "user",
+                "malicious_intent": true,
+                "applicability_to_org": "high"
+            },
+            {
+                "symbolic_name": "michiko",
+                "title": "Michiko",
+                "description": "Michiko levareges a lot of acquired knowledge from her e-crime organization which enables her to launch sophisticated attacks penetrating internal corporate networks",
+                "is_person": true,
+                "skill_level": "oc_sponsored",
+                "access_level": "admin",
+                "malicious_intent": true,
+                "applicability_to_org": "moderate"
+            }
+        ],
+        "threats":[
+            {
+                "symbolic_name": "buffer-overflow-image-processing",
+                "title": "Buffer overflow in image processing causing remote code execution or DoS",
+                "description": "An attacker crafts an image to cause buffer overflow in image processing, leading to potential remote code execution, denial of service, and errors.",
+                "threat_persona": "ratimir",
+                "event": "denial of service or remote code execution",
+                "sources": ["adversary"],
+                "attack_mechanism": {
+                    "capec_id": 100,
+                    "capec_title": "Overflow Buffers"
+                },
+                "vulnerabilities": [
+                    {
+                        "cwe_id": 120,
+                        "cwe_title": "Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')"
+                    }
+                ]
+            },
+            {
+                "symbolic_name": "supply-chain-attack",
+                "title": "Supply chain attack on third-party libraries compromising system outputs",
+                "description": "An attacker poisons the supply chain of third-party libraries, leading to network or system compromise.",
+                "threat_persona": "ratimir",
+                "event": "supply chain attack",
+                "sources": ["adversary"],
+                "attack_mechanism": {
+                    "capec_id": 438,
+                    "capec_title": "Modification During Manufacture"
+                },
+                "vulnerabilities": [
+                    {
+                        "cwe_id": 1104,
+                        "cwe_title": "Use of Unmaintained Third Party Components"
+                    }
+                ]
+            },
+            {
+                "symbolic_name": "image-tampering",
+                "title": "Image Tampering",
+                "description": "An attacker tampers with or deletes stored images to impact training or testing results and/or cause denial of service.",
+                "threat_persona": "michiko",
+                "event": "Image tampering",
+                "sources": ["adversary"],
+                "attack_mechanism": {
+                    "capec_id": 1,
+                    "capec_title": "Accessing Functionality Not Properly Constrained by acls"
+                },
+                "vulnerabilities": [
+                    {
+                        "cwe_id": 276,
+                        "cwe_title": "Incorrect Default Permissions"
+                    },
+                    {
+                        "cwe_id": 285,
+                        "cwe_title": "Improper Authorization"
+                    }
+                ]
+            },
+            {
+                "symbolic_name": "notebook-tampering",
+                "title": "Notebook tampering to insert a backdoor",
+                "description": "An attacker modifies a notebook file to insert a backdoor, such as a keylogger or data stealer.",
+                "threat_persona": "michiko",
+                "event": "notebook tampering",
+                "sources": ["adversary"],
+                "attack_mechanism": {
+                    "capec_id": 1,
+                    "capec_title": "Accessing Functionality Not Properly Constrained by acls"
+                },
+                "vulnerabilities": [
+                    {
+                        "cwe_id": 276,
+                        "cwe_title": "Incorrect Default Permissions"
+                    },
+                    {
+                        "cwe_id": 285,
+                        "cwe_title": "Improper Authorization"
+                    }
+                ]
+            },
+            {
+                "symbolic_name": "model-tampering",
+                "title": "Machine learning model tampering causing low accuracy or IP theft",
+                "description": "An attacker or insider modifies or reads persisted model files to steal intellectual property or degrade prediction accuracy.",
+                "threat_persona": "michiko",
+                "event": "machine learning model tampering",
+                "sources": ["adversary"],
+                "attack_mechanism": {
+                    "capec_id": 1,
+                    "capec_title": "Accessing Functionality Not Properly Constrained by acls"
+                },
+                "vulnerabilities": [
+                    {
+                        "cwe_id": 276,
+                        "cwe_title": "Incorrect Default Permissions"
+                    },
+                    {
+                        "cwe_id": 285,
+                        "cwe_title": "Improper Authorization"
+                    }
+                ]
+            },
+            {
+                "symbolic_name": "perturbation-attack",
+                "title": "Image perturbation attack resulting in incorrect classifications",
+                "description": "An attacker uses brute force with random or systematic perturbations to create images that lead to incorrect classifications.",
+                "threat_persona": "ratimir",
+                "event": "perturbation attack",
+                "sources": ["adversary"],
+                "attack_mechanism": {
+                    "capec_id": 28,
+                    "capec_title": "Fuzzing"
+                },
+                "vulnerabilities": [
+                    {
+                        "cwe_id": 20,
+                        "cwe_title": "Improper Input Validation"
+                    }
+                ]
+            },
+            {
+                "symbolic_name": "sensitive-image-exposure",
+                "title": "Sensitive image exposure due to accidental access",
+                "description": "An attacker or malicious insider gains access to sensitive uploaded images.",
+                "threat_persona": "michiko",
+                "event": "accidental sensitive data exposure",
+                "sources": ["adversary"],
+                "attack_mechanism": {
+                    "capec_id": 204,
+                    "capec_title": "Lifting Sensitive Data Embedded in Cache"
+                },
+                "vulnerabilities": [
+                    {
+                        "cwe_id": 20,
+                        "cwe_title": "Improper Input Validation"
+                    }
+                ]
+            },
+            {
+                "symbolic_name": "ssh-compromise-developer-machine",
+                "title": "SSH compromise via stolen credentials from developer machine",
+                "description": "An attacker compromises a developer machine to steal SSH keys, impersonate users, or escalate privileges.",
+                "threat_persona": "michiko",
+                "event": "bastion compromise via SSH",
+                "sources": ["adversary"],
+                "attack_mechanism": {
+                    "capec_id": 555,
+                    "capec_title": "Remote Services with Stolen Credentials"
+                },
+                "vulnerabilities": [
+                    {
+                        "cwe_id": 522,
+                        "cwe_title": "Insufficiently Protected Credentials"
+                    }
+                ]
+            },
+            {
+                "symbolic_name": "ssh-compromise-vulnerability",
+                "title": "SSH compromise via open port vulnerability",
+                "description": "An attacker exploits an open SSH port to escalate privileges or impersonate authorized users.",
+                "threat_persona": "ratimir",
+                "event": "bastion compromise via SSH",
+                "sources": ["adversary"],
+                "attack_mechanism": {
+                    "capec_id": 300,
+                    "capec_title": "Port Scanning"
+                },
+                "vulnerabilities": [
+                    {
+                        "cwe_id": 200,
+                        "cwe_title": "Exposure of Sensitive Information to an Unauthorized Actor"
+                    }
+                ]
+            }
+        ],        
+        "mitigations": [
+            {
+                "symbolic_name": "sandboxing-for-image-processing",
+                "title": "Implement sandboxing for image processing",
+                "description": "Run image processing in isolated environment to limit impact of exploitation",
+                "threats": ["buffer-overflow-image-processing"],
+                "trust_boundary": {
+                    "trust_zone_a": "public",
+                    "trust_zone_b": "prod-zone"
+                },
+                "status": "suggested",
+                "priority": "medium"
+            },
+            {
+                "symbolic_name": "owasp-file-upload-guidelines",
+                "title": "Follow OWASP Cheat Sheet for File Upload",
+                "description": "Run image processing in isolated environment to limit impact of exploitation",
+                "threats": ["buffer-overflow-image-processing"],
+                "trust_boundary": {
+                    "trust_zone_a": "public",
+                    "trust_zone_b": "prod-zone"
+                },
+                "status": "suggested",
+                "priority": "critical"
+            },
+            {
+                "symbolic_name": "validate-tls-certificate-checks",
+                "title": "Validate TLS usage and certificate checks are in place",
+                "description": "Validate TLS usage and certificate checks are in place.",
+                "threats": ["supply-chain-attack"],
+                "trust_boundary": {
+                    "trust_zone_a": "public",
+                    "trust_zone_b": "prod-zone"
+                },
+                "status": "suggested",
+                "priority": "critical"
+            },
+            {
+                "symbolic_name": "sca-and-patching-for-third-party-libraries",
+                "title": "SCA scanning and patching",
+                "description": "Regularly scan third-party dependencies for vulnerabilities and malicious packages, fix any critical or high vulnerabilities",
+                "threats": ["supply-chain-attack"],
+                "trust_boundary": {
+                    "trust_zone_a": "public",
+                    "trust_zone_b": "prod-zone"
+                },
+                "status": "suggested",
+                "priority": "critical"
+            },
+            {
+                "symbolic_name": "access-control-for-azure-blobs",
+                "title": "Ensure appropriate access control and authorization for any Azure Blob storage",
+                "description": "Use ABAC, rbac, and other access control methods to ensure only authorized individuals can access the images.",
+                "threats": ["image-tampering", "model-tampering"],
+                "trust_boundary": {
+                    "trust_zone_a": "public",
+                    "trust_zone_b": "prod-zone"
+                },
+                "status": "active",
+                "priority": "critical"
+            },
+            {
+                "symbolic_name": "access-logging-for-azure-blob",
+                "title": "Have access logging in place for Azure Blob storage",
+                "description": "Turn on access logging for the Azure Blob and push logs to a SIEM for monitoring.",
+                "threats": ["image-tampering", "model-tampering"],
+                "trust_boundary": {
+                    "trust_zone_a": "public",
+                    "trust_zone_b": "prod-zone"
+                },
+                "status": "suggested",
+                "priority": "high"
+            },
+            {
+                "symbolic_name": "backup-for-azure-blob-storage",
+                "title": "Ensure backups for Azure Blob storage with different credentials",
+                "description": "Ensure images have a backup stored securely and cannot be accessed with the same credentials as the production storage.",
+                "threats": ["image-tampering", "model-tampering"],
+                "trust_boundary": {
+                    "trust_zone_a": "public",
+                    "trust_zone_b": "prod-zone"
+                },
+                "status": "suggested",
+                "priority": "high"
+            },
+            {
+                "symbolic_name": "store-and-check-hashes",
+                "title": "Store hashes and validate integrity of images, jupyter notebooks and the machine learning models",
+                "description": "Protect Jupyter Notebooks and the machine learning models from tampering by using stored hashes and validating them.",
+                "threats": ["image-tampering", "model-tampering","notebook-tampering"],
+                "trust_boundary": {
+                    "trust_zone_a": "public",
+                    "trust_zone_b": "prod-zone"
+                },
+                "status": "suggested",
+                "priority": "high"
+            },
+            {
+                "symbolic_name": "jupyter-notebooks-access-control",
+                "title": "Ensure appropriate access control and authorization in place for the Jupyter Notebooks",
+                "description": "Use ABAC, rbac and other access control methods to ensure only people who are authorised can access Jupyter Notebooks.",
+                "threats": ["notebook-tampering"],
+                "trust_boundary": {
+                    "trust_zone_a": "public",
+                    "trust_zone_b": "experimental-zone"
+                },
+                "status": "active",
+                "priority": "critical"
+            },
+            {
+                "symbolic_name": "api-rate-limiting",
+                "title": "Rate Limiting",
+                "description": "Prevent brute force by restricting the number of requests an API client can make in a time frame.",
+                "threats": ["perturbation-attack"],
+                "trust_boundary": {
+                    "trust_zone_a": "public",
+                    "trust_zone_b": "prod-zone"
+                },
+                "status": "suggested",
+                "priority": "high"
+            },
+            {
+                "symbolic_name": "adversarial-training",
+                "title": "Adversarial Training",
+                "description": "Train the model with adversarial examples to improve robustness against perturbation attacks.",
+                "threats": ["perturbation-attack"],
+                "trust_boundary": {
+                    "trust_zone_a": "public",
+                    "trust_zone_b": "prod-zone"
+                },
+                "status": "suggested",
+                "priority": "medium"
+            },
+            {
+                "symbolic_name": "input-filtering",
+                "title": "Input Filtering",
+                "description": "Detect and block adversarial inputs through preprocessing or anomaly detection.",
+                "threats": ["perturbation-attack"],
+                "trust_boundary": {
+                    "trust_zone_a": "public",
+                    "trust_zone_b": "prod-zone"
+                },
+                "status": "suggested",
+                "priority": "high"
+            },
+            {
+                "symbolic_name": "confidence-thresholding",
+                "title": "Confidence Thresholding",
+                "description": "Set thresholds to avoid over-reliance on high-confidence but incorrect predictions.",
+                "threats": ["perturbation-attack"],
+                "trust_boundary": {
+                    "trust_zone_a": "public",
+                    "trust_zone_b": "prod-zone"
+                },
+                "status": "suggested",
+                "priority": "medium"
+            },
+            {
+                "symbolic_name": "in-memory-image-storage",
+                "title": "The uploaded images are saved in memory - difficult to access",
+                "description": "The fact that images are not inherently sensitive and stored in memory mitigates this threat to an acceptable level.",
+                "threats": ["sensitive-image-exposure"],
+                "trust_boundary": {
+                    "trust_zone_a": "public",
+                    "trust_zone_b": "prod-zone"
+                },
+                "status": "active",
+                "priority": "medium"
+            },
+            {
+                "symbolic_name": "memory-access-restrictions",
+                "title": "Memory access restrictions",
+                "description": "Implement strict memory access restrictions to ensure only authorized processes or users can access the in-memory or cached data. This includes using mechanisms like process isolation and restricting debug or system tools that could read memory.",
+                "threats": ["sensitive-image-exposure"],
+                "trust_boundary": {
+                    "trust_zone_a": "public",
+                    "trust_zone_b": "prod-zone"
+                },
+                "status": "suggested",
+                "priority": "low"
+            },
+            {
+                "symbolic_name": "secure-cache-handling",
+                "title": "Secure cache-handling",
+                "description": "Use secure caching mechanisms that encrypt data stored in memory (e.g., using libraries like Redis with in-memory encryption) and ensure the cache has strict eviction policies to avoid prolonged data retention.",
+                "threats": ["sensitive-image-exposure"],
+                "trust_boundary": {
+                    "trust_zone_a": "public",
+                    "trust_zone_b": "prod-zone"
+                },
+                "status": "suggested",
+                "priority": "low"
+            },
+            {
+                "symbolic_name": "in-memory-data-lifecycle-management",
+                "title": "In-memory data lifecycle management",
+                "description": "Implement a strict lifecycle management policy to securely clear in-memory data immediately after use. For example, overwrite memory regions containing sensitive data and enforce short caching lifespans.",
+                "threats": ["sensitive-image-exposure"],
+                "trust_boundary": {
+                    "trust_zone_a": "public",
+                    "trust_zone_b": "prod-zone"
+                },
+                "status": "suggested",
+                "priority": "low"
+            },
+            {
+                "symbolic_name": "network-acl-ssh-restrictions",
+                "title": "Use network-level access control lists (acls) to limit SSH access to specific IP ranges",
+                "description": "Whitelist SSH ports to allow access only from specific IPs.",
+                "threats": ["ssh-compromise-developer-machine", "ssh-compromise-vulnerability"],
+                "trust_boundary": {
+                    "trust_zone_a": "public",
+                    "trust_zone_b": "prod-zone"
+                },
+                "status": "suggested",
+                "priority": "critical"
+            },
+            {
+                "symbolic_name": "complex-ssh-passphrases",
+                "title": "Require passphrases for SSH private keys to be complex",
+                "description": "Passphrases for SSH keys should have high complexity (minimum 12 characters and one type of complexity).",
+                "threats": ["ssh-compromise-developer-machine"],
+                "trust_boundary": {
+                    "trust_zone_a": "user-key-store",
+                    "trust_zone_b": "ssh-service"
+                },
+                "status": "suggested",
+                "priority": "medium"
+            },
+            {
+                "symbolic_name": "developer-machine-security",
+                "title": "Developer machine endpoint security - EDR and posture management",
+                "description": "Ensure developer machines are patched, have an up-to-date OS, and EDR in place.",
+                "threats": ["ssh-compromise-developer-machine", "image-tampering", "model-tampering","notebook-tampering"],
+                "trust_boundary": {
+                    "trust_zone_a": "developer-machine",
+                    "trust_zone_b": "endpoint-detection-response"
+                },
+                "status": "suggested",
+                "priority": "critical"
+            },
+            {
+                "symbolic_name": "ssh-access-logging",
+                "title": "Configure logging for all SSH access attempts",
+                "description": "Log all access attempts - including successes and failures, and implement alerting for suspicious activities such as repeated login failures, new keys, or logins from unexpected locations.",
+                "threats": ["ssh-compromise-developer-machine", "ssh-compromise-vulnerability"],
+                "trust_boundary": {
+                    "trust_zone_a": "ssh-service",
+                    "trust_zone_b": "logging-and-monitoring-system"
+                },
+                "status": "active",
+                "priority": "high"
+            },
+            {
+                "symbolic_name": "bastion-host-patching-hardening",
+                "title": "Ensure the Bastion host is patched and hardened",
+                "description": "Have strict patching SLAs for the Bastion host.",
+                "threats": ["ssh-compromise-vulnerability"],
+                "trust_boundary": {
+                    "trust_zone_a": "external-network",
+                    "trust_zone_b": "bastion-host"
+                },
+                "status": "suggested",
+                "priority": "critical"
+            }
+        ],
+        "risks": [
+            {
+                "symbolic_name": "adversarial-attack-on-huskyai",
+                "title": "Adversarial attacks on the HuskyAI model",
+                "description": "Attackers could manipulate the HuskyAI model through perturbation techniques or tampering with the training and testing sets, leading to incorrect predictions and erosion of trust in the system.",
+                "threats": ["image-tampering", "model-tampering","notebook-tampering", "perturbation-attack"],
+                "likelihood": "unlikely",
+                "impact": "major",
+                "impact_description": "Operational issues and loss of user confidence - reputational damage.",
+                "score": 8,
+                "level": "medium"
+            },
+            {
+                "symbolic_name": "web-attacks",
+                "title": "Web Attacks",
+                "description": "An attacker could launch web based attacks by sending crafted requests, leading to outages and reputational damage.",
+                "threats": ["supply-chain-attack", "buffer-overflow-image-processing"],
+                "likelihood": "possible",
+                "impact": "moderate",
+                "impact_description": "Operational disruptions could arise from endpoint flooding or configuration tampering, leading to downtime and reputational damage.",
+                "score": 9,
+                "level": "high"
+            },
+            {
+                "symbolic_name": "unauthorized-ssh-access",
+                "title": "Unauthorized SSH access via stolen or compromised keys",
+                "description": "An attacker could gain unauthorized access to sensitive systems via stolen or compromised SSH keys, or by attacking the SSH port directly - leading to privilege escalation, information disclosure, reputational damage and potential operational disruption.",
+                "threats": ["ssh-compromise-developer-machine", "ssh-compromise-vulnerability"],
+                "likelihood": "possible",
+                "impact": "severe",
+                "impact_description": "Operational disruption requiring moderate to high recovery efforts with potentially reputational damage.",
+                "score": 15,
+                "level": "high"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
`threat-model.schema.json`: Numerous updates, partially based on 2025-04-02 CycloneDX WG feedback.

- Clean up schema `title`.
- `typed-symbolic-name` schema: Rename `name` property to `object`; the semantics remain the same.
- `control-status` enum: Rename from `mitigation-status`. "Mitigation" is the process of implementing controls.
- `data-sensitivity` enum: Add `op` value, representing operational data.
- `tier`: Drop `N_` prefixes from enum values.
- `access-control-method` enum:
  - Rename from `access_control_method`. Type names use dashes, property names (and enum values) use underscores.
  - Add `none` value.
- `authentication-method` enum:
  - Add `none` value.
  - Add `challenge_response` value.
- `trust-boundary` schema: `access_control_methods`, `authentication_methods` renamed from singular forms (they already contained arrays).
- `data-set` schema: `access_control_methods` renamed from singular form (it already contained an array).
- `assumption` schema: `validity` enum: `unconfirmed` value renamed from `assumed`.
- `threat` schema:
  - `components_affected`: Added with an array of components that are affected by the threat.
  - `attack_mechanisms` now contains an array (was: `attack_mechanism` with a single mechanism).
  - `weaknesses`: Renamed from `vulnerabilities`.
- `controls`: Renamed from `mitigations`. "Mitigation" is the process of implementing controls.
- `data_stores`: Renamed from singular form (it already contained an array).
- Eliminated `outputs` container and moved all its contained properties to the top level. The input/output distinction is arbitrary.
- `extensions`: Add as top-level property to act as an escape hatch, allowing users to specify arbitrary (but well-defined) extensions.