### PR TITLE
Add `trust_zone` to actor and data store schemas

### DIFF
--- a/threat-model.schema.json
+++ b/threat-model.schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/OWASP/www-project-threat-model-library/blob/v1.0.1/threat-model.schema.json",
-    "$comment": "When updating the schema `$id`, also update the value of the constant `$schema` property below.",
+    "$comment": "When updating the schema `$id`, also update the value of the constant `$schema` property below. See <https://owasp.org/www-project-threat-model-library/#div-specification>.",
     "title": "OWASP Threat Model Library Schema",
 
     "$defs": {
@@ -752,12 +752,12 @@
                 },
                 "score": {
                     "title": "Risk score based on likelihood and impact",
-                    "$comment": "https://owasp.org/www-project-threat-model-library/",
+                    "$comment": "https://owasp.org/www-project-threat-model-library/#div-specification",
                     "$ref": "#/$defs/risk-score"
                 },
                 "level": {
                     "title": "Risk level band",
-                    "$comment": "https://owasp.org/www-project-threat-model-library/",
+                    "$comment": "https://owasp.org/www-project-threat-model-library/#div-specification",
                     "$ref": "#/$defs/risk-level-band"
                 }
             }

--- a/threat-model.schema.json
+++ b/threat-model.schema.json
@@ -76,6 +76,9 @@
             "minimum": 0,
             "maximum": 25
         },
+        "risk-level-band": {
+            "enum": ["very_low", "low", "medium", "high", "very_high", "critical"]
+        },
         "tier": {
             "enum": ["mission_critical", "business_critical", "important", "non_critical"]
         },
@@ -755,7 +758,7 @@
                 "level": {
                     "title": "Risk level band",
                     "$comment": "https://owasp.org/www-project-threat-model-library/",
-                    "type": "string"
+                    "$ref": "#/$defs/risk-level-band"
                 }
             }
         },

--- a/threat-model.schema.json
+++ b/threat-model.schema.json
@@ -302,7 +302,8 @@
                 "symbolic_name",
                 "title",
                 "description",
-                "type"
+                "type",
+                "trust_zone"
             ],
             "additionalProperties": false,
             "properties": {
@@ -325,6 +326,10 @@
                 "permissions": {
                     "title": "Free-form description of permissions typically available to the actor",
                     "type": "string"
+                },
+                "trust_zone": {
+                    "title": "Trust zone in which the actor operates",
+                    "$ref": "#/$defs/symbolic-name"
                 }
             }
         },
@@ -373,7 +378,8 @@
                 "symbolic_name",
                 "title",
                 "description",
-                "type"
+                "type",
+                "trust_zone"
             ],
             "additionalProperties": false,
             "properties": {
@@ -400,6 +406,10 @@
                 "product": {
                     "title": "Product implementing the data store",
                     "type": "string"
+                },
+                "trust_zone": {
+                    "title": "Trust zone where the data store resides",
+                    "$ref": "#/$defs/symbolic-name"
                 }
             }
         },
@@ -739,12 +749,12 @@
                 },
                 "score": {
                     "title": "Risk score based on likelihood and impact",
-                    "$comment": "http://go/threat-modeling-risk-score",
+                    "$comment": "https://owasp.org/www-project-threat-model-library/",
                     "$ref": "#/$defs/risk-score"
                 },
                 "level": {
                     "title": "Risk level band",
-                    "$comment": "http://go/threat-modeling-risk-score",
+                    "$comment": "https://owasp.org/www-project-threat-model-library/",
                     "type": "string"
                 }
             }


### PR DESCRIPTION
Both actor and data-store now require a trust_zone field.

trust_zone references an existing symbolic trust zone (by name).

This aligns them with component which already had a trust_zone.