### PR TITLE
relax schema to allow 1.x.x versions

### DIFF
--- a/threat-model.schema.json
+++ b/threat-model.schema.json
@@ -804,7 +804,7 @@
     "properties": {
         "$schema": {
             "title": "URI of JSON schema",
-            "const": "https://github.com/OWASP/www-project-threat-model-library/blob/v1.0.2/threat-model.schema.json"
+            "pattern": "https://github\\.com/OWASP/www-project-threat-model-library/blob/v[1-9][0-9]*\\.[0-9]+\\.[0-9]+/threat-model.schema.json"
         },
 
         "version": {


### PR DESCRIPTION
This provides a pattern, rather than a constant, in the schema so that the the $schema value matches to versions 1.0.0 and above
This closes #31 